### PR TITLE
Allow skipping document opening

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -50,12 +50,11 @@ where W: Write {
     namespaces: Vec<(String, String)>,
     current_tag: String,
     current_tag_attrs: Option<HashMap<&'static str, String>>,
-    open_document: bool,
 }
 
 impl<W: Write> Serializer<W> {
     pub fn new_from_writer(
-        writer: EventWriter<W>, default_ns: Option<&str>, namespaces: &[(&str, &str)], open_document: bool
+        writer: EventWriter<W>, default_ns: Option<&str>, namespaces: &[(&str, &str)]
     ) -> Self {
         let namespaces = namespaces.into_iter()
             .map(|(prefix, uri)| (prefix.to_string(), uri.to_string()))
@@ -67,7 +66,6 @@ impl<W: Write> Serializer<W> {
             namespaces,
             current_tag: "".into(),
             current_tag_attrs: None,
-            open_document: open_document,
         }
     }
 
@@ -75,7 +73,7 @@ impl<W: Write> Serializer<W> {
         Self::new_from_writer(
             EmitterConfig::new()
             .perform_indent(true)
-            .create_writer(writer), default_ns, namespaces, true)
+            .create_writer(writer), default_ns, namespaces)
     }
 
     fn next(&mut self, event: XmlEvent) -> Result<()> {
@@ -86,20 +84,9 @@ impl<W: Write> Serializer<W> {
     	self.next(XmlEvent::characters(s))
     }
 
-    fn start_document(&mut self) -> Result<()> {
-        self.next(XmlEvent::StartDocument {
-            encoding: Default::default(),
-            standalone: Default::default(),
-            version: xml::common::XmlVersion::Version10
-        })
-    }
-
     fn open_root_tag(&mut self, name: &'static str) -> Result<()> {
         if self.root {
             self.root = false;
-            if self.open_document {
-                self.start_document()?;
-            }
             self.open_tag(name)?;
         }
         Ok(())

--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -24,7 +24,7 @@ fn one_element() {
     let input = Document { value: "plain text".to_string() };
 
     let expected = indoc!(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <document>
           <value>plain text</value>
         </document>"#);
@@ -59,7 +59,7 @@ fn test_custom_header() {
         let mut writer = EmitterConfig::new()
             .perform_indent(true)
             .create_writer(&mut buf);
-        
+
         writer.write(XmlEvent::StartDocument {
             encoding: Default::default(),
             standalone: Default::default(),
@@ -70,10 +70,10 @@ fn test_custom_header() {
            Some("VERSION=\"203\"")
         )).unwrap();
 
-        let mut ser = Serializer::new_from_writer(writer, None, &[], false);
+        let mut ser = Serializer::new_from_writer(writer, None, &[]);
         input.serialize(&mut ser).unwrap();
     }
-   
+
 
     let actual = String::from_utf8(buf).map_err(error::from_utf8).unwrap();
 
@@ -99,7 +99,7 @@ fn nested_elements() {
     let input = Document { inner: InnerElement { value: "plain text".to_string() } };
 
     let expected = indoc!(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <document>
           <inner>
             <value>plain text</value>
@@ -128,7 +128,7 @@ fn multiple_elements() {
     };
 
     let expected = indoc!(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <document>
           <first>plain text</first>
           <second>more text</second>
@@ -157,7 +157,7 @@ fn map() {
     };
 
     let expected1 = indoc!(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <document>
           <content>
             <first.key>plain text</first.key>
@@ -166,7 +166,7 @@ fn map() {
         </document>"#);
 
     let expected2 = indoc!(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <document>
           <content>
             <second-key>more text</second-key>
@@ -197,7 +197,7 @@ fn sequence() {
     };
 
     let expected = indoc!(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <document>
           <item>first</item>
           <item>second</item>
@@ -231,7 +231,7 @@ fn unit_variant() {
     };
 
     let expected = indoc!(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <document>
           <content>a</content>
         </document>"#);
@@ -277,7 +277,7 @@ fn struct_variant() {
     };
 
     let expected = indoc!(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <document>
           <content>
             <trump>
@@ -315,7 +315,7 @@ fn newtype_variant() {
     };
 
     let expected = indoc!(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <document>
           <content>
             <i>42</i>
@@ -352,7 +352,7 @@ fn tuple_variant() {
     };
 
     let expected = indoc!(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <document>
           <content>
             <kv>abc 123</kv>
@@ -383,7 +383,7 @@ fn tuple_struct() {
     };
 
     let expected = indoc!(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <document>
           <content>abc 123</content>
         </document>"#);
@@ -408,7 +408,7 @@ fn tuple() {
     };
 
     let expected = indoc!(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <document>
           <content>123 1.23 abc</content>
         </document>"#);
@@ -433,7 +433,7 @@ fn types_unit() {
     };
 
     let expected = indoc!(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <document>
           <content />
         </document>"#);
@@ -462,7 +462,7 @@ fn unit_struct() {
     };
 
     let expected = indoc!(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <document>
           <content />
         </document>"#);
@@ -491,7 +491,7 @@ fn newtype_struct() {
     };
 
     let expected = indoc!(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <document>
           <content>abc</content>
         </document>"#);
@@ -519,7 +519,7 @@ mod option {
         };
 
         let expected = indoc!(r#"
-            <?xml version="1.0" encoding="UTF-8"?>
+            <?xml version="1.0" encoding="utf-8"?>
             <document>
               <content />
             </document>"#);
@@ -538,7 +538,7 @@ mod option {
         };
 
         let expected = indoc!(r#"
-            <?xml version="1.0" encoding="UTF-8"?>
+            <?xml version="1.0" encoding="utf-8"?>
             <document>
               <content>123</content>
             </document>"#);
@@ -574,7 +574,7 @@ mod attribute {
         };
 
         let expected = indoc!(r#"
-            <?xml version="1.0" encoding="UTF-8"?>
+            <?xml version="1.0" encoding="utf-8"?>
             <document>
               <content id="123" />
             </document>"#);
@@ -611,12 +611,12 @@ mod attribute {
         };
 
         let expected1 = indoc!(r#"
-            <?xml version="1.0" encoding="UTF-8"?>
+            <?xml version="1.0" encoding="utf-8"?>
             <document>
               <content x="20" y="40" />
             </document>"#);
         let expected2 = indoc!(r#"
-            <?xml version="1.0" encoding="UTF-8"?>
+            <?xml version="1.0" encoding="utf-8"?>
             <document>
               <content y="40" x="20" />
             </document>"#);
@@ -644,7 +644,7 @@ mod attribute {
         };
 
         let expected = indoc!(r#"
-            <?xml version="1.0" encoding="UTF-8"?>
+            <?xml version="1.0" encoding="utf-8"?>
             <document version="1.2.3" />"#);
 
         let actual = to_string(&input).unwrap();
@@ -670,7 +670,7 @@ mod attribute {
         };
 
         let expected = indoc!(r#"
-            <?xml version="1.0" encoding="UTF-8"?>
+            <?xml version="1.0" encoding="utf-8"?>
             <document version="1.2.3">
               <content>abc</content>
             </document>"#);
@@ -707,7 +707,7 @@ mod attribute {
         };
 
         let expected = indoc!(r#"
-            <?xml version="1.0" encoding="UTF-8"?>
+            <?xml version="1.0" encoding="utf-8"?>
             <document>
               <content id="123">abc</content>
             </document>"#);
@@ -737,7 +737,7 @@ mod ns {
         };
 
         let expected = indoc!(r#"
-            <?xml version="1.0" encoding="UTF-8"?>
+            <?xml version="1.0" encoding="utf-8"?>
             <document xmlns="urn:example:document">
               <content>abc 123</content>
             </document>"#);
@@ -763,7 +763,7 @@ mod ns {
         };
 
         let expected = indoc!(r#"
-            <?xml version="1.0" encoding="UTF-8"?>
+            <?xml version="1.0" encoding="utf-8"?>
             <document xmlns:content="urn:example:content">
               <content:content>abc 123</content:content>
             </document>"#);
@@ -789,7 +789,7 @@ mod ns {
         };
 
         let expected = indoc!(r#"
-            <?xml version="1.0" encoding="UTF-8"?>
+            <?xml version="1.0" encoding="utf-8"?>
             <document xmlns:content="urn:example:content" content:content="abc 123" />"#);
 
         let actual = to_string_ns(&input, None, &[("content", "urn:example:content")]).unwrap();


### PR DESCRIPTION
Hello!

Here's an idea I was playing around with this morning.  The document I'm trying to recreate has a processing statement that comes before the rest of the document, which I couldn't do with how things were set up initially.

I'll add some inline comments, but let me know what you think.

Thanks for putting this crate together by the way, it's been really useful.